### PR TITLE
feat: Add precalib-avg- lows/highs for OOTB setup.

### DIFF
--- a/drivers/kscan/zmk_kscan_ec_matrix.c
+++ b/drivers/kscan/zmk_kscan_ec_matrix.c
@@ -812,10 +812,18 @@ static int zkem_pm_action(const struct device *dev, enum pm_device_action action
 
 #define ENTRIES(n) DT_INST_PROP_LEN(n, strobe_gpios) * DT_INST_PROP_LEN(n, input_gpios)
 
+#define FOREACH_STROBE_CALIB_ENTRY(n, prop, idx)                                                   \
+    {.avg_low = DT_PROP_BY_IDX(n, precalib_avg_lows, idx),                                         \
+     .avg_high = DT_PROP_BY_IDX(n, precalib_avg_highs, idx)}
+
 #define ZKEM_INIT(n)                                                                               \
     PM_DEVICE_DT_INST_DEFINE(n, zkem_pm_action);                                                   \
     COND_CODE_1(DT_INST_NODE_HAS_PROP(n, pinctrl_names), (PINCTRL_DT_INST_DEFINE(n);), ())         \
-    static struct zmk_kscan_ec_matrix_calibration_entry calibration_entries_##n[ENTRIES(n)] = {0}; \
+    static struct zmk_kscan_ec_matrix_calibration_entry calibration_entries_##n[ENTRIES(n)] = {    \
+        COND_CODE_1(DT_INST_NODE_HAS_PROP(n, precalib_avg_lows),                                   \
+                    (DT_INST_FOREACH_PROP_ELEM_SEP(n, precalib_avg_lows,                           \
+                                                   FOREACH_STROBE_CALIB_ENTRY, (, ))),             \
+                    (0))};                                                                         \
     static uint64_t reported_matrix_states_##n[DT_INST_PROP_LEN(n, strobe_gpios)] = {0};           \
     COND_CODE_1(                                                                                   \
         DT_INST_NODE_HAS_PROP(n, strobe_input_masks),                                              \

--- a/dts/bindings/kscan/zmk,kscan-ec-matrix.yaml
+++ b/dts/bindings/kscan/zmk,kscan-ec-matrix.yaml
@@ -48,6 +48,12 @@ properties:
     type: phandle-array
   io-channels:
     required: true
+  precalib-avg-lows:
+    type: array
+    description: Pre-seeded avg low calibration values
+  precalib-avg-highs:
+    type: array
+    description: Pre-seeded avg high calibration values
   
   pinctrl-0:
     required: false


### PR DESCRIPTION
Add the ability to set `precalib-avg-lows` and `precalib-avg-highs` props with arrays of calibration data, and add new `export` shell command to export that data from a fully calibrated device, allowing for some sane default values for basic functionality before running a proper calibration for the specific calibrated keyboard.