### PR TITLE
feat: Add `trigger-percentage` config

### DIFF
--- a/dts/bindings/kscan/zmk,kscan-ec-matrix.yaml
+++ b/dts/bindings/kscan/zmk,kscan-ec-matrix.yaml
@@ -8,6 +8,10 @@ compatible: "zmk,kscan-ec-matrix"
 include: [kscan.yaml, pinctrl-device.yaml]
 
 properties:
+  trigger-percentage:
+    type: int
+    default: 50
+    description: Pressed threshold as a percentage of the full range, where 0% is not pressed at all and 100% is pressed fully.
   skip-startup-calibration:
     type: boolean
   active-polling-interval-ms:


### PR DESCRIPTION
* Add ability to set a `trigger-percentage` value between 10 and 90 to control what percentage of the total travel triggers a press.